### PR TITLE
fixed dependent bot packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,6 @@
 version: 2
 updates:
-  # 1. Core Project Dependencies (Change "npm" to "pip", "docker", "bundler", etc. if needed)
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-
-  # 2. GitHub Actions Security Updates (Keeps your CI/CD workflows up-to-date)
+  # GitHub Actions Security Updates (Keeps your CI/CD workflows up-to-date)
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
### Problem
The `dependabot.yml` file was configured with `package-ecosystem: "npm"` pointing to the root directory (`/`). Because this is a C/C++ project utilizing a `Makefile` and native sources rather than a Node.js environment, there is no `package.json` file in the repository. This caused Dependabot to fail and log configuration errors.

### Fix
- Removed the invalid `npm` package ecosystem entry entirely.
- Kept the `github-actions` ecosystem entry, which remains valid and highly useful for keeping our CI/CD workflows up-to-date.

### File Changes
`.github/dependabot.yml`

```yml
version: 2
updates:
  # GitHub Actions Security Updates (Keeps our CI/CD workflows up-to-date)
  - package-ecosystem: "github-actions"
    directory: "/"
    schedule:
      interval: "weekly"
```