### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["main", "master"]
 
+permissions:
+  contents: read
+
 jobs:
   build-windows:
     runs-on: windows-latest


### PR DESCRIPTION
Potential fix for [https://github.com/toxicbishop/Crypt-Vault/security/code-scanning/2](https://github.com/toxicbishop/Crypt-Vault/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root in `.github/workflows/build.yml`, directly under the trigger section (`on:` block) and before `jobs:`.  
Use least privilege for current behavior:

- `contents: read`

This is the minimal and appropriate permission for `actions/checkout` and local build/test steps, and it does not change workflow functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
